### PR TITLE
apiURL removed from environment.ts 

### DIFF
--- a/src/app/professional.service.ts
+++ b/src/app/professional.service.ts
@@ -1,14 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, Subject } from 'rxjs';
-import { environment } from '../environments/environment'
 
 @Injectable({
   providedIn: 'root'
 })
 export class ProfessionalService {
 
-  private baseUrl = environment.apiUrl.concat('/api/professionals/');
+  private baseUrl = '/api/professionals/';
   
   constructor(private http: HttpClient) { }
 

--- a/src/app/skill.service.ts
+++ b/src/app/skill.service.ts
@@ -1,27 +1,26 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../environments/environment'
 
 @Injectable({
   providedIn: 'root'
 })
 export class SkillService {
   
-  private baseUrl = environment.apiUrl.concat('/api/skills/');
+  private skillUrl = '/api/skills/';
     
   constructor(private http: HttpClient) { }
 
   createSkill(skill: Object ): Observable<Object> {
-    return this.http.post(`${this.baseUrl}`, skill);
+    return this.http.post(`${this.skillUrl}`, skill);
   }
 
   getSkillList(): Observable<any> {
-    return this.http.get(`${this.baseUrl}`);
+    return this.http.get(`${this.skillUrl}`);
   }
 
   deleteSkill(idSkill: number): Observable<any> {
-    return this.http.delete(`${this.baseUrl}/${idSkill}`, { responseType: 'text' });
+    return this.http.delete(`${this.skillUrl}/${idSkill}`, { responseType: 'text' });
   }
 
 

--- a/src/app/state.service.ts
+++ b/src/app/state.service.ts
@@ -1,14 +1,13 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { environment } from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StateService {
 
-  private stateUrl = environment.apiUrl.concat('/api/states/');
+  private stateUrl = '/api/states/';
 
   constructor(private http: HttpClient) { }
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,8 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false,
-  apiUrl: 'http://localhost:8080'
+  production: false
 };
 
 /*


### PR DESCRIPTION
Quando tive problema com o CORS, iniciei o browser com o parâmetro --disable-web-security e criei uma variável no angular para apontar para a API (apiURL), porém, ao conversar com o Marlon, ele me explicou que já havia passado por isso e para resolver usou uma configuração de proxy (angular.proxy.ts). Iniciando o projeto com 'npm start', que foi configurado no arquivo 'package.json', o projeto roda com a configuração de proxy no próprio servidor do angular e o usa para acessar o back-end sem aplicar o CORS.  